### PR TITLE
Ensure that logical volume is activated

### DIFF
--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -75,6 +75,20 @@ class Chef
           Chef::Log.info "Logical volume '#{name}' already exists. Not creating..."
         end
 
+        vg = lvm.volume_groups[new_resource.group]
+        # If logical volume is not activated, activate it
+        if vg.nil? || lvol = vg.logical_volumes.find { |lv| lv.name == name }
+          if lvol.active
+            Chef::Log.info "Logical volume '#{name}' already activated."
+          else
+            Chef::Log.info "Activating logical volume '#{name}'"
+            command = "lvchange -aly #{lvol.path}"
+            Chef::Log.debug "Executing lvm command: '#{command}'"
+            output = lvm.raw(command)
+            Chef::Log.debug "Command output: '#{output}'"
+          end
+        end
+
         # If file system is specified, format the logical volume
         if fs_type.nil?
           Chef::Log.info 'File system type is not set. Not formatting...'


### PR DESCRIPTION
This pull request resolves an issue where /dev/mapper/... is missing and subsequently causes a failure when the filesystem is checked or created.   This situation happens during the case were we create a new ebs volume from snapshot that contained an already provisioned volume group and logical volume.  These restored logical volumes are initially marked inactive.  