### PR TITLE
Fix Chef 12.1.0 chef_gem resource warnings

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,11 +21,13 @@ package 'lvm2'
 
 chef_gem 'di-ruby-lvm-attrib' do
   action :install
+  compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
   version node['lvm']['di-ruby-lvm-attrib']['version']
 end
 
 chef_gem 'di-ruby-lvm' do
   action :install
+  compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
   version node['lvm']['di-ruby-lvm']['version']
 end
 


### PR DESCRIPTION
Fix Chef 12.1.0 chef_gem resource warnings by setting compile_time to false.