### PR TITLE
Added "compile_time false if respond_to?(:compile_time)"

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,11 +22,13 @@ package 'lvm2'
 chef_gem 'di-ruby-lvm-attrib' do
   action :install
   version node['lvm']['di-ruby-lvm-attrib']['version']
+  compile_time false if respond_to?(:compile_time)
 end
 
 chef_gem 'di-ruby-lvm' do
   action :install
   version node['lvm']['di-ruby-lvm']['version']
+  compile_time false if respond_to?(:compile_time)
 end
 
 # Start+Enable the lvmetad service on RHEL7, it is required by default


### PR DESCRIPTION
I was having trouble including the lvm cookbook as part of a run list in an environment that does not have direct access to ruby-gems.org, but configures the instance to use nexus as part of the run list.

i.e. The gem cannot be installed compile time, but after certain other resources in the run list have converged the chef-gem resource is able to install the required gems.

I have tested that adding "compile_time false if respond_to?(:compile_time)" to both chef-gems to insure compile_time installation is disabled as discussed: https://docs.chef.io/resource_chef_gem.html both passes existing kitchen tests and resolves the issue in my environment.

Would this be a good addition to the lvm cookbook?