### PR TITLE
Add a wipe_signatures option to LVM volume group

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,19 @@ Manages LVM volume groups.
     <td></td>
     <td></td>
   </tr>
+  <tr>
+    <td>wipe_signatures</td>
+    <td>Force the creation of the Volume Group, even if `lvm` detects existing non-LVM data on disk</td>
+    <td>`true`</td>
+    <td>`false`</td>
+  </tr>
 </table>
 
 ##### Examples
 ```ruby
 lvm_volume_group 'vg00' do
   physical_volumes ['/dev/sda', '/dev/sdb', '/dev/sdc']
+  wipe_signatures true
 
   logical_volume 'logs' do
     size        '1G'

--- a/libraries/provider_lvm_volume_group.rb
+++ b/libraries/provider_lvm_volume_group.rb
@@ -126,7 +126,8 @@ class Chef
         else
           physical_volumes = physical_volume_list.join(' ')
           physical_extent_size = new_resource.physical_extent_size ? "-s #{new_resource.physical_extent_size}" : ''
-          command = "vgcreate #{name} #{physical_extent_size} #{physical_volumes}"
+          yes_flag = new_resource.wipe_signatures == true ? '--yes' : ''
+          command = "vgcreate #{name} #{physical_extent_size} #{physical_volumes} #{yes_flag}"
           Chef::Log.debug "Executing lvm command: '#{command}'"
           output = lvm.raw command
           Chef::Log.debug "Command output: '#{output}'"

--- a/libraries/resource_lvm_volume_group.rb
+++ b/libraries/resource_lvm_volume_group.rb
@@ -112,6 +112,21 @@ class Chef
         @logical_volumes << volume
         volume
       end
+
+      # Attribute: wipe_signature -
+      #
+      # @param arg [Boolean] whether to automatically wipe any preexisting partitions
+      #
+      # @return [Boolean] the wipe_signature setting
+      #
+      def wipe_signatures(arg = nil)
+        set_or_return(
+          :wipe_signatures,
+          arg,
+          kind_of: [TrueClass, FalseClass],
+          default: false
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
As mentioned in https://github.com/chef-cookbooks/lvm/issues/45 -  RHEL7's lvm command now interactively prompts users with a `WARNING: ext3 signature detected on /dev/xvdb at offset 1080. Wipe it? [y/n]` message. 

This is particularly painful for AWS users, where ephemeral volumes come preformatted with ext3.

This PR adds a `wipe_signatures` option to `lvm_volume_group` that looks like so:

```ruby
  lvm_volume_group 'opscode' do
    physical_volumes [ '/dev/xvdb', '/dev/xvdc' ]
    wipe_signatures true
  end
```

This feature comes with a big CAVEAT EMPTOR that it will wipe out the physical volumes provided to `lvm_volume_group` -  but this is the behavior you already get with lvm on RHEL <= 6 and all of the Ubuntu so really the point here is to have platform parity for RHEL7.