### PR TITLE
Set compilte ttime to false for the chef_gem resources.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,11 +22,13 @@ package 'lvm2'
 chef_gem 'di-ruby-lvm-attrib' do
   action :install
   version node['lvm']['di-ruby-lvm-attrib']['version']
+  compile_time false if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
 end
 
 chef_gem 'di-ruby-lvm' do
   action :install
   version node['lvm']['di-ruby-lvm']['version']
+  compile_time false if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
 end
 
 # Start+Enable the lvmetad service on RHEL7, it is required by default


### PR DESCRIPTION
Compile time being true causes issues in environments where systems do not have direct internet access and the proxies are set up in the run list.  

I have tested that setting compile time to false avoid such issues and the existing suite of tests continues to run. 