### PR TITLE
Bump versions for di-ruby-lvm and di-ruby-lvm-attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
-default['lvm']['di-ruby-lvm']['version'] = '0.1.3'
-default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.21'
+default['lvm']['di-ruby-lvm']['version'] = '0.2.0'
+default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.22'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -10,10 +10,10 @@ describe 'lvm::default' do
   end
 
   it 'installs `di-ruby-lvm-attrib` as a Ruby gem' do
-    expect(chef_run).to install_chef_gem('di-ruby-lvm-attrib').with(version: '0.0.21')
+    expect(chef_run).to install_chef_gem('di-ruby-lvm-attrib').with(version: '0.0.22')
   end
 
   it 'installs `di-ruby-lvm` as a Ruby gem' do
-    expect(chef_run).to install_chef_gem('di-ruby-lvm').with(version: '0.1.3')
+    expect(chef_run).to install_chef_gem('di-ruby-lvm').with(version: '0.2.0')
   end
 end


### PR DESCRIPTION
`di-lvm-ruby` has some performance enhancements for systems with large numbers of volume groups. `di-lvm-ruby-attributes` adds support for two more versions of lvm.