### PR TITLE
Fix Issue 71

### DIFF
--- a/libraries/resource_lvm_logical_volume.rb
+++ b/libraries/resource_lvm_logical_volume.rb
@@ -155,7 +155,12 @@ class Chef
             ': location must be an absolute path!' => proc do |value|
               # this can be a string or a hash, so attempt to match either for
               # the regex
-              matches = value =~ %r{^/[^\0]*} || value[:location] =~ %r{^/[^\0]*}
+              matches = case value.class
+                        when String
+                          value =~ %r{^/[^\0]*}
+                        when Hash
+                          value[:location] =~ %r{^/[^\0]*}
+                        end
               !matches.nil?
             end
           }


### PR DESCRIPTION
While the actual problem for #71 was caused by not specifying an absolute path for the mount point location, it tickled a latent bug in the validation logic where, if the mount point was specified as a string, and the string validation failed, it would then attempt to treat the string like a hash, which did not work. This change makes it so that only strings are checked as strings should be checked, and only hashes are checked as hashes should be checked.