### PR TITLE
Bugfix: case uses === not == so "case value" not "case value.class"

### DIFF
--- a/libraries/resource_lvm_logical_volume.rb
+++ b/libraries/resource_lvm_logical_volume.rb
@@ -155,7 +155,7 @@ class Chef
             ': location must be an absolute path!' => proc do |value|
               # this can be a string or a hash, so attempt to match either for
               # the regex
-              matches = case value.class
+              matches = case value
                         when String
                           value =~ %r{^/[^\0]*}
                         when Hash


### PR DESCRIPTION
2.2.3 :009 > case "something".class
2.2.3 :010?>   when String
2.2.3 :011?>   puts 'String!'
2.2.3 :012?>   end
 => nil
2.2.3 :013 > case "something"
2.2.3 :014?>   when String
2.2.3 :015?>   puts 'String!'
2.2.3 :016?>   end
String!