### PR TITLE
Include lvm recipe so lvm gems are installed for tests

### DIFF
--- a/test/fixtures/cookbooks/test/recipes/create.rb
+++ b/test/fixtures/cookbooks/test/recipes/create.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include_recipe 'lvm'
+
 # The test device to use
 devices = [
   '/dev/loop0',

--- a/test/fixtures/cookbooks/test/recipes/resize.rb
+++ b/test/fixtures/cookbooks/test/recipes/resize.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include_recipe 'lvm'
+
 execute 'extend loop0 device' do
   command <<-EOF
 dd if=/dev/zero bs=512 count=65536 >> /vfile0


### PR DESCRIPTION
Fixes https://github.com/chef-cookbooks/lvm/issues/86 which is caused by the lvm gems not being installed before the tests use them.