### PR TITLE
fix di-ruby-lvm-attrib attribute version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 default['lvm']['di-ruby-lvm']['version'] = '0.2.1'
 default['lvm']['di-ruby-lvm']['compile_time'] = false
 
-default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.23'
+default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.25'
 default['lvm']['di-ruby-lvm-attrib']['compile_time'] = false

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -10,7 +10,7 @@ describe 'lvm::default' do
   end
 
   it 'installs `di-ruby-lvm-attrib` as a Ruby gem' do
-    expect(chef_run).to install_chef_gem('di-ruby-lvm-attrib').with(version: '0.0.23')
+    expect(chef_run).to install_chef_gem('di-ruby-lvm-attrib').with(version: '0.0.25')
   end
 
   it 'installs `di-ruby-lvm` as a Ruby gem' do


### PR DESCRIPTION
This fixes issues with di-ruby-lvm-attrib gem not having the correct version stored for latest lvm updates.