### PR TITLE
Update di-ruby-lvm-attrib #98

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,7 +28,7 @@ suites:
   - name: create_thin
     excludes:
     - centos-5.11
-    - debian-7.9
+    - debian-7.10
     - ubuntu-12.04
     run_list:
       - recipe[test::create_thin]
@@ -39,7 +39,7 @@ suites:
   - name: resize_thin
     excludes:
     - centos-5.11
-    - debian-7.9
+    - debian-7.10
     - ubuntu-12.04
     run_list:
       - recipe[test::create_thin]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,4 +18,4 @@
 #
 
 default['lvm']['di-ruby-lvm']['version'] = '0.2.1'
-default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.25'
+default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.26'


### PR DESCRIPTION
### Description

This change updates di-ruby-lvm-attrib to the latest version

### Issues Resolved

#98 

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

Kitchen tests are failing on ubuntu-1604 but this was already happening before this change. I have made a PR for a fix, https://github.com/gregsymons/di-ruby-lvm-attrib/pull/46