### PR TITLE
Moving include dsl:recipe out of resource namespace

### DIFF
--- a/libraries/base_resource_logical_volume.rb
+++ b/libraries/base_resource_logical_volume.rb
@@ -24,6 +24,8 @@ class Chef
     # Base class that contains common attributes for all logical volume resources
     #
     class BaseLogicalVolume < Chef::Resource
+      include Chef::DSL::Recipe
+
       # Initializes a BaseLogicalVolume object.  This class is only meant to
       # be used as a base class for other resources.
       #

--- a/libraries/resource_lvm_thin_pool.rb
+++ b/libraries/resource_lvm_thin_pool.rb
@@ -22,8 +22,6 @@ require_relative 'resource_lvm_logical_volume'
 
 class Chef
   class Resource
-    include Chef::DSL::Recipe
-
     # The lvm_thin_pool resource
     #
     # A thin pool is a logical volume that can contain thin volumes (which are also logical volumes but are "thin")


### PR DESCRIPTION
### Description

Because we are including dsl:recipe in the resource namespace other cookbooks using a custom resource are picking it up and breaking.

### Issues Resolved
None known.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

Kitchen tests are failing on ubuntu-1604, once di-ruby-lvm-attrib's next version is released we should see these clear.
Kitchen tests are also failing on centos-511. It appears the line that we are using to resize the loop device for the test is incorrect which is causing the test to fail. The cookbook converges but the test will fail checking extents.


