### PR TITLE
Update to di-ruby-lvm-attrib 0.0.27

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,4 +18,4 @@
 #
 
 default['lvm']['di-ruby-lvm']['version'] = '0.2.1'
-default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.26'
+default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.27'


### PR DESCRIPTION
### Description

Update to `di-ruby-lvm-attrib` 0.0.27. 0.0.26 is lacking the metadata needed on Ubuntu 16.04.

### Issues Resolved

#105

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>

thin tests are failing due to a different issue. non-thin tests pass.

- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

