### PR TITLE
"yes_flag" aka the "wipe_signatures" attribute for PVs and LVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Manages LVM physical volumes.
     <td><tt>'/dev/sda'</tt></td>
     <td></td>
   </tr>
+  <tr>
+    <td>wipe_signatures</td>
+    <td>Force the creation of the Logical Volume, even if `lvm` detects existing PV signatures/td>
+    <td>`true`</td>
+    <td>`false`</td>
+  </tr>
 </table>
 
 #### Examples
@@ -184,6 +190,12 @@ Manages LVM logical volumes.
     <td>whether to have the LV take up the remainder of free space on the VG. Only valid for resize action</td>
     <td><tt>true</tt></td>
     <td>false</td>
+  </tr>
+  <tr>
+    <td>wipe_signatures</td>
+    <td>Force the creation of the Logical Volume, even if `lvm` detects existing LV signatures/td>
+    <td>`true`</td>
+    <td>`false`</td>
   </tr>
 </table>
 

--- a/libraries/base_resource_logical_volume.rb
+++ b/libraries/base_resource_logical_volume.rb
@@ -164,19 +164,6 @@ class Chef
           }
         )
       end
-      # Attribute: yes - answer yes to all questions
-      #
-      # @param arg [Bool] true, false
-      #
-      # @return [Bool] true, false
-      #
-      def yes(arg = nil)
-        set_or_return(
-          :yes,
-          arg,
-          kind_of: Bool
-        )
-      end
     end
   end
 end

--- a/libraries/base_resource_logical_volume.rb
+++ b/libraries/base_resource_logical_volume.rb
@@ -164,6 +164,19 @@ class Chef
           }
         )
       end
+      # Attribute: yes - answer yes to all questions
+      #
+      # @param arg [Bool] true, false
+      #
+      # @return [Bool] true, false
+      #
+      def yes(arg = nil)
+        set_or_return(
+          :yes,
+          arg,
+          kind_of: Bool
+        )
+      end
     end
   end
 end

--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -235,12 +235,13 @@ class Chef
         mirrors = new_resource.mirrors ? "--mirrors #{new_resource.mirrors}" : ''
         contiguous = new_resource.contiguous ? '--contiguous y' : ''
         readahead = new_resource.readahead ? "--readahead #{new_resource.readahead}" : ''
+        yes_flag = new_resource.wipe_signatures == true ? '--yes' : ''
         lv_params = new_resource.lv_params
         name = new_resource.name
         group = new_resource.group
         physical_volumes = [new_resource.physical_volumes].flatten.join ' ' if new_resource.physical_volumes
 
-        "lvcreate #{size} #{stripes} #{stripe_size} #{mirrors} #{contiguous} #{readahead} #{lv_params} --name #{name} #{group} #{physical_volumes}"
+        "lvcreate #{size} #{stripes} #{stripe_size} #{mirrors} #{contiguous} #{readahead} #{lv_params} --name #{name} #{group} #{physical_volumes} #{yes_flag}"
       end
 
       def resize_command(lv_size_req)

--- a/libraries/provider_lvm_physical_volume.rb
+++ b/libraries/provider_lvm_physical_volume.rb
@@ -45,9 +45,10 @@ class Chef
       def action_create
         require_lvm_gems
         lvm = LVM::LVM.new
+        yes_flag = new_resource.wipe_signatures == true ? '--yes' : ''
         if lvm.physical_volumes[new_resource.name].nil?
           Chef::Log.info "Creating physical volume '#{new_resource.name}'"
-          lvm.raw "pvcreate #{new_resource.name}"
+          lvm.raw "pvcreate #{new_resource.name} #{yes_flag}"
           new_resource.updated_by_last_action(true)
         else
           Chef::Log.info "Physical volume '#{new_resource.name}' found. Not creating..."

--- a/libraries/resource_lvm_logical_volume.rb
+++ b/libraries/resource_lvm_logical_volume.rb
@@ -148,6 +148,7 @@ class Chef
           kind_of: [TrueClass, FalseClass]
         )
       end
+
       # Attribute: wipe_signature -
       #
       # @param arg [Boolean] whether to automatically wipe any preexisting signatures

--- a/libraries/resource_lvm_logical_volume.rb
+++ b/libraries/resource_lvm_logical_volume.rb
@@ -148,6 +148,20 @@ class Chef
           kind_of: [TrueClass, FalseClass]
         )
       end
+      # Attribute: wipe_signature -
+      #
+      # @param arg [Boolean] whether to automatically wipe any preexisting signatures
+      #
+      # @return [Boolean] the wipe_signature setting
+      #
+      def wipe_signatures(arg = nil)
+        set_or_return(
+          :wipe_signatures,
+          arg,
+          kind_of: [TrueClass, FalseClass],
+          default: false
+        )
+      end
     end
   end
 end

--- a/libraries/resource_lvm_physical_volume.rb
+++ b/libraries/resource_lvm_physical_volume.rb
@@ -55,6 +55,7 @@ class Chef
           required: true
         )
       end
+
       # Attribute: wipe_signature -
       #
       # @param arg [Boolean] whether to automatically wipe any preexisting signatures

--- a/libraries/resource_lvm_physical_volume.rb
+++ b/libraries/resource_lvm_physical_volume.rb
@@ -55,6 +55,20 @@ class Chef
           required: true
         )
       end
+      # Attribute: wipe_signature -
+      #
+      # @param arg [Boolean] whether to automatically wipe any preexisting signatures
+      #
+      # @return [Boolean] the wipe_signature setting
+      #
+      def wipe_signatures(arg = nil)
+        set_or_return(
+          :wipe_signatures,
+          arg,
+          kind_of: [TrueClass, FalseClass],
+          default: false
+        )
+      end
     end
   end
 end

--- a/libraries/resource_lvm_volume_group.rb
+++ b/libraries/resource_lvm_volume_group.rb
@@ -141,19 +141,6 @@ class Chef
         @logical_volumes << volume
         volume
       end
-      # Attribute: answeryes - answer yes to all questions
-      #
-      # @param arg [Boolean] whether to answer yes to all questions
-      #
-      # @return [Boolean] if answer yes to all questions
-      #
-      def answeryes(arg = nil)
-        set_or_return(
-          :answeryes,
-          arg,
-          kind_of: [TrueClass, FalseClass]
-        )
-      end
     end
   end
 end

--- a/libraries/resource_lvm_volume_group.rb
+++ b/libraries/resource_lvm_volume_group.rb
@@ -115,7 +115,7 @@ class Chef
 
       # Attribute: wipe_signature -
       #
-      # @param arg [Boolean] whether to automatically wipe any preexisting partitions
+      # @param arg [Boolean] whether to automatically wipe any preexisting signatures
       #
       # @return [Boolean] the wipe_signature setting
       #
@@ -140,6 +140,19 @@ class Chef
         volume.action :nothing
         @logical_volumes << volume
         volume
+      end
+      # Attribute: answeryes - answer yes to all questions
+      #
+      # @param arg [Boolean] whether to answer yes to all questions
+      #
+      # @return [Boolean] if answer yes to all questions
+      #
+      def answeryes(arg = nil)
+        set_or_return(
+          :answeryes,
+          arg,
+          kind_of: [TrueClass, FalseClass]
+        )
       end
     end
   end


### PR DESCRIPTION
### Description

The adds the "yes_flag" aka the "wipe_signatures" attribute also to PVs and LVs.

### Issues Resolved

I have an environment were existing LV metadata is present and without the "--yes" flag the LV would not be created and the "lvcreate" would hang forever.

### Check List

- [ x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [not needed/possible ] New functionality includes testing.
- [x ] New functionality has been documented in the README if applicable
- [x ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
