### PR TITLE
add platformintrospection dsl

### DIFF
--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -20,6 +20,7 @@
 require 'chef/provider'
 require 'chef/mixin/shell_out'
 require 'chef/dsl/recipe'
+require 'chef/dsl/platform_introspection'
 require File.join(File.dirname(__FILE__), 'lvm')
 
 class Chef
@@ -29,6 +30,7 @@ class Chef
     class LvmLogicalVolume < Chef::Provider
       include Chef::DSL::Recipe
       include Chef::Mixin::ShellOut
+      include Chef::DSL::PlatformIntrospection
       include LVMCookbook
 
       # Loads the current resource attributes


### PR DESCRIPTION
Signed-off-by: Jeremy J. Miller <jm@chef.io>

### Description

Adding in the `Chef::DSL::PlatformIntrospection` namespace to allow `platform_family?` to work.

### Issues Resolved

This change fixes: #115

```
================================================================================
Error executing action `create` on resource 'lvm_logical_volume[volume]'
================================================================================

NoMethodError
-------------
No resource or method named `platform_family?' for `Chef::Provider::LvmLogicalVolume ""'

Cookbook Trace:
---------------
/tmp/kitchen/cache/cookbooks/lvm/libraries/provider_lvm_logical_volume.rb:221:in `install_filesystem_deps'
/tmp/kitchen/cache/cookbooks/lvm/libraries/provider_lvm_logical_volume.rb:47:in `action_create'`
```

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>