### PR TITLE
Remove deprecation notice in 4.0.1

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  deprecations_as_errors: true
 
 platforms:
   - name: centos-5.11

--- a/libraries/lvm.rb
+++ b/libraries/lvm.rb
@@ -20,12 +20,14 @@ module LVMCookbook
     raise 'The previous di-ruby-lvm and di-ruby-lvm-attrib gems have been replaced with chef maintained forks. You have set the legacy attributes for pinning installed gem versions. You will need to remove these attributes and instead set the new chef varients. See the attributes file for the latest attributes.' if node['lvm']['di-ruby-lvm'] || node['lvm']['di-ruby-lvm-attrib']
 
     if node['lvm']['cleanup_old_gems']
-      chef_gem 'di-ruby-lvm-attrib' do
+      chef_gem "#{new_resource.name}_di-ruby-lvm-attrib_removal" do
+        package_name 'di-ruby-lvm-attrib'
         action :remove
         compile_time true
       end
 
-      chef_gem 'di-ruby-lvm' do
+      chef_gem "#{new_resource.name}_di-ruby-lvm_removal" do
+        package_name 'di-ruby-lvm'
         action :remove
         compile_time true
       end


### PR DESCRIPTION
### Description

Solves the following deprecation notice in 4.0.1
```
Deprecated features used!
  Cloning resource attributes for chef_gem[di-ruby-lvm-attrib] from prior resource (CHEF-3694)
Previous chef_gem[di-ruby-lvm-attrib]: /tmp/kitchen/cache/cookbooks/lvm/libraries/lvm.rb:24:in `require_lvm_gems'
Current  chef_gem[di-ruby-lvm-attrib]: /tmp/kitchen/cache/cookbooks/lvm/libraries/lvm.rb:24:in `require_lvm_gems' at 1 location:
    - /tmp/kitchen/cache/cookbooks/lvm/libraries/lvm.rb:24:in `require_lvm_gems'
  Cloning resource attributes for chef_gem[di-ruby-lvm] from prior resource (CHEF-3694)
Previous chef_gem[di-ruby-lvm]: /tmp/kitchen/cache/cookbooks/lvm/libraries/lvm.rb:29:in `require_lvm_gems'
Current  chef_gem[di-ruby-lvm]: /tmp/kitchen/cache/cookbooks/lvm/libraries/lvm.rb:29:in `require_lvm_gems' at 1 location:
    - /tmp/kitchen/cache/cookbooks/lvm/libraries/lvm.rb:29:in `require_lvm_gems'
```

### Issues Resolved

https://github.com/chef-cookbooks/lvm/issues/114

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
