### PR TITLE
Obvious fix: for size in extents --extents should be used

### DIFF
--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -242,7 +242,7 @@ class Chef
           when /(\d{1,2}|100)%(FREE|VG|PVS)/
             "--extents #{new_resource.size}"
           when /(\d+)/
-            "--size #{$1}" # rubocop:disable PerlBackrefs
+            "--extents #{$1}" # rubocop:disable PerlBackrefs
           end
 
         stripes = new_resource.stripes ? "--stripes #{new_resource.stripes}" : ''


### PR DESCRIPTION
Signed-off-by: Stanislav Voroniy <stas@voroniy.com>

### Description
Obvious fix
Fix LV creation size when specified in extents