### PR TITLE
Don't try to start lvmetad service on Amazon Linux

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@ package 'lvm2'
 
 # Start+Enable the lvmetad service on RHEL7, it is required by default
 # but not automatically started
-if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 7
+if node['platform_family'] == 'rhel' && node[platform] != 'amazon' && node['platform_version'].to_i >= 7
   service 'lvm2-lvmetad' do
     action [:enable, :start]
     provider Chef::Provider::Service::Systemd


### PR DESCRIPTION
### Description

Amazon Linux was updated (https://aws.amazon.com/amazon-linux-ami/2017.03-release-notes/) and LVM cookbook will now fail trying to start lvmetad service. Adding rather safe condition to skip this resource on Amazon Linux.

This is how attributes look like on newest Amazon Linux instance:
node['platform'] => amazon
node['platform_family'] => rhel
node['platform_version'] => 2017.03

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
