### PR TITLE
remove provider specification when starting lvm2-lvmetad, use the default provider that the system can discover

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,6 @@ package 'lvm2'
 if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 7
   service 'lvm2-lvmetad' do
     action [:enable, :start]
-    provider Chef::Provider::Service::Systemd
     only_if '/sbin/lvm dumpconfig global/use_lvmetad | grep use_lvmetad=1'
   end
 end


### PR DESCRIPTION
not all redhat 7 family uses `systemd` as service startup. Amazon Linux  2017 is classified redhat family, but it doesn't use `systemd`, instead if uses `init.d`

The attribute on amazon linux 2017 is
```
node['platform'] => amazon
node['platform_family'] => rhel
node['platform_version'] => 2017.03
```

it will satisfy the check condition, but it will fail at starting the `lvm2-lvmetad` service using `systemd` provider (because it doesn't use `systemd`, instead it uses `init.d`

```
[ec2-user@ip-172-31-20-128 ~]$ sudo service lvm2-lvmetad status
lvmetad (pid  1891) is running...
[ec2-user@ip-172-31-20-128 ~]$ cat /etc/os-release 
NAME="Amazon Linux AMI"
VERSION="2017.03"
ID="amzn"
ID_LIKE="rhel fedora"
VERSION_ID="2017.03"
PRETTY_NAME="Amazon Linux AMI 2017.03"
ANSI_COLOR="0;33"
CPE_NAME="cpe:/o:amazon:linux:2017.03:ga"
HOME_URL="http://aws.amazon.com/amazon-linux-ami/"
```

I believe the original change is to ensure `lvm2-lvmetad` is `enabled/started`, so lvm partition will work on redhat families. Hence I believe we should still include this for amazon linux 2017. Just need to make sure it's `enabled/started` by the correct provider

The change is to allow the `lvm2-lvmetad` service to be started using the system's default service startup provider