### PR TITLE
adding source for the air gaped environment use case

### DIFF
--- a/libraries/lvm.rb
+++ b/libraries/lvm.rb
@@ -26,12 +26,14 @@ module LVMCookbook
         package_name 'di-ruby-lvm-attrib'
         action :remove
         compile_time true
+        source node['lvm']['rubysource']
       end
 
       chef_gem "#{new_resource.name}_di-ruby-lvm_removal" do
         package_name 'di-ruby-lvm'
         action :remove
         compile_time true
+        source node['lvm']['rubysource']
       end
     end
 


### PR DESCRIPTION
### Description
Had the gem remove resources look at node['lvm']['rubysource'] so that it would would speed of the use of the resources

### Issues Resolved

 #121 - Removal of old gem fails

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
