### PR TITLE
Add missing matchers for lvm thin pools and volumes

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -20,7 +20,13 @@
 if defined?(ChefSpec)
   # Per the comment on https://github.com/sethvargo/chefspec/issues/241#issuecomment-26725772 runner_methods have to be defined
   # if this isn't done you cannot test if resource A notifies resource B
-  [:lvm_logical_volume, :lvm_physical_volume, :lvm_volume_group].each do |method|
+  %i(
+    lvm_logical_volume
+    lvm_physical_volume
+    lvm_volume_group
+    lvm_thin_pool
+    lvm_thin_volume
+  ).each do |method|
     ChefSpec.define_matcher method
   end
 
@@ -46,5 +52,21 @@ if defined?(ChefSpec)
 
   def extend_lvm_volume_group(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:lvm_volume_group, :extend, resource_name)
+  end
+
+  def create_lvm_thin_pool(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:lvm_thin_pool, :create, resource_name)
+  end
+
+  def resize_lvm_thin_pool(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:lvm_thin_pool, :resize, resource_name)
+  end
+
+  def create_lvm_thin_volume(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:lvm_thin_volume, :create, resource_name)
+  end
+
+  def resize_lvm_thin_volume(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:lvm_thin_volume, :resize, resource_name)
   end
 end


### PR DESCRIPTION
### Description

Adds missing ChefSpec matchers for the `lvm_thin_pool` and `lvm_thin_volume` LWRPs.

### Issues Resolved

There are currently matchers missing for the `lvm_thin_pool` and `lvm_thin_volume` LWRPs.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
