### PR TITLE
Remove end.run_action(:install) as it breaks SUSE runs

### DIFF
--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -222,9 +222,7 @@ class Chef
       def install_filesystem_deps
         if platform_family?('suse') && /^ext/.match(new_resource.filesystem)
           Chef::Log.debug('Installing e2fsprogs to create the filesystem')
-          package 'e2fsprogs' do
-            action :nothing
-          end
+          package 'e2fsprogs'
         else
           Chef::Log.debug('Not installing any packages to configure the filesystem')
         end

--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -224,7 +224,7 @@ class Chef
           Chef::Log.debug('Installing e2fsprogs to create the filesystem')
           package 'e2fsprogs' do
             action :nothing
-          end.run_action(:install)
+          end
         else
           Chef::Log.debug('Not installing any packages to configure the filesystem')
         end


### PR DESCRIPTION
Description

Found that trying to install packages at compile-time breaks our SUSE runs, as repositories have not yet been configured.

The .run_action here should only necessary for things like Chef gems where the compile would otherwise fail as resources couldn't be defined. It is sufficient to install the package here at runtime.

Issues Resolved

Breaking SUSE run when trying to install packages at compile-time