### PR TITLE
Correct raise syntax to remove the invalid second argument, fixes #141

### DIFF
--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -137,13 +137,13 @@ class Chef
         vg = lvm.volume_groups[group]
         # if doing a resize make sure that the volume exists before doing anything
 
-        raise("Error volume group #{group} does not exist", 2) if vg.nil?
+        raise("Error volume group #{group} does not exist") if vg.nil?
 
         lv = vg.logical_volumes.select do |lvs|
           lvs.name == name
         end
         # make sure that the LV specified exists in the VG specified
-        raise("Error logical volume #{name} does not exist", 2) if lv.empty?
+        raise("Error logical volume #{name} does not exist") if lv.empty?
 
         lv = lv.first
         pe_size = lvm.volume_groups[group].extent_size.to_i
@@ -179,7 +179,7 @@ class Chef
                         when /^(\d+)$/
                           Regexp.last_match[1].to_i
                         else
-                          raise("Invalid size #{Regexp.last_match[1]} for lvm resize", 2)
+                          raise("Invalid size #{Regexp.last_match[1]} for lvm resize")
                         end
         # calculate the number of extents needed differently if specifying a percentage
         elsif resize_type == 'percent'
@@ -189,16 +189,16 @@ class Chef
                         when 'VG'
                           ((percent.to_f / 100) * pe_count).to_i
                         when 'FREE'
-                          raise('Cannot percentage based off free space', 2) unless new_resource.take_up_free_space
+                          raise('Cannot percentage based off free space') unless new_resource.take_up_free_space
                           (((percent.to_f / 100) * pe_free) + lv_size_cur).to_i
                         else
-                          raise("Invalid type #{type} for resize. You can only resize using an explicit size, percentage of VG or by setting take_up_free_space to true", 2)
+                          raise("Invalid type #{type} for resize. You can only resize using an explicit size, percentage of VG or by setting take_up_free_space to true")
                         end
         else
-          raise("Invalid size specification #{lv_size}", 2)
+          raise("Invalid size specification #{lv_size}")
         end
 
-        raise("Error trying to extend logical volume #{lv.name} beyond the capacity of volume group #{group}", 2) if !thin_volume? && (lv_size_req - lv_size_cur) > pe_free
+        raise("Error trying to extend logical volume #{lv.name} beyond the capacity of volume group #{group}") if !thin_volume? && (lv_size_req - lv_size_cur) > pe_free
 
         # don't resize if the current size is greater than or equal to the target size
         if lv_size_cur >= lv_size_req

--- a/libraries/provider_lvm_volume_group.rb
+++ b/libraries/provider_lvm_volume_group.rb
@@ -72,7 +72,7 @@ class Chef
         lvm = LVM::LVM.new
 
         # verify that the volume group is valid
-        raise("VG #{name} is not a valid volume group", 2) if lvm.volume_groups[name].nil?
+        raise("VG #{name} is not a valid volume group") if lvm.volume_groups[name].nil?
 
         # get uuid of the volume group so we can compare it to the VG the PV belongs to
         vg_uuid = lvm.volume_groups[name].uuid
@@ -89,7 +89,7 @@ class Chef
             pvs_to_add.push pv_name
           else
             # raise an error if we attempt to add a PV that is already a member of a VG
-            raise("PV #{pv} is already a member of another volume group. Cannot add to #{name}", 2) unless pv_vg_uuid == vg_uuid
+            raise("PV #{pv} is already a member of another volume group. Cannot add to #{name}") unless pv_vg_uuid == vg_uuid
           end
         end
 


### PR DESCRIPTION
Signed-off-by: Matthew Newell <matthewtnewell@gmail.com>

### Description

This change fixes the `raise` syntax to use the correct call format by removing the second argument. It appears that this was missed when the `Chef::Application.fatal!` calls were converted to use `raise` instead.

### Issues Resolved

This fixes issue #141 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing. (N/A, marking complete due to no new functionality)
- [x] New functionality has been documented in the README if applicable (N/A, marking complete due to no new functionality)
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
