### PR TITLE
Add support for the ignore_skipped_cluster property, fixes #156

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Action  | Description
 
 #### Properties
 
-Property        | Description                                                                                | Example  | Default
---------------- | ------------------------------------------------------------------------------------------ | -------- | -------
-name            | (required) The device to create the new physical volume on                                 | /dev/sda |
-wipe_signatures | Force the creation of the Logical Volume, even if `lvm` detects existing PV signatures/td> | `true`   | `false`
+Property               | Description                                                                            | Example  | Default
+---------------------- | -------------------------------------------------------------------------------------- | -------- | -------
+name                   | (required) The device to create the new physical volume on                             | /dev/sda |
+wipe_signatures        | Force the creation of the Logical Volume, even if `lvm` detects existing PV signatures | `true`   | `false`
+ignore_skipped_cluster | Continue execution even if `lvm` detects skipped clustered volume groups               | `true`   | `false`
 
 #### Examples
 
@@ -170,13 +171,19 @@ Action  | Description
   <td>take_up_free_space</td>
     <td>whether to have the LV take up the remainder of free space on the VG. Only valid for resize action</td>
     <td><tt>true</tt></td>
-    <td>false</td>
+    <td><tt>false</tt></td>
   </tr>
   <tr>
     <td>wipe_signatures</td>
-    <td>Force the creation of the Logical Volume, even if `lvm` detects existing LV signatures/td>
-    <td>`true`</td>
-    <td>`false`</td>
+    <td>Force the creation of the Logical Volume, even if `lvm` detects existing LV signatures</td>
+    <td><tt>true</tt></td>
+    <td><tt>false</tt></td>
+  </tr>
+  <tr>
+    <td>ignore_skipped_cluster</td>
+    <td>Continue execution even if `lvm` detects skipped clustered volume groups</td>
+    <td><tt>true</tt></td>
+    <td><tt>false</tt></td>
   </tr>
 </table>
 
@@ -455,14 +462,15 @@ Action  | Description
 
 #### Properties
 
-Property             | Description                                                                                                                                                                | Example                           | Default
--------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------
-name                 | (required) Name of the volume group                                                                                                                                        | <tt>'bacon'</tt>                  |
-physical_volumes     | (required) The device or list of devices to use as physical volumes (if they haven't already been initialized as physical volumes, they will be initialized automatically) | <tt>['/dev/sda', '/dev/sdb']</tt> |
-physical_extent_size | The physical extent size for the volume group                                                                                                                              |                                   |
-logical_volume       | Shortcut for creating a new `lvm_logical_volume` definition (the logical volumes will be created in the order they are declared)                                           |                                   |
-wipe_signatures      | Force the creation of the Volume Group, even if `lvm` detects existing non-LVM data on disk                                                                                | `true`                            | `false`
-thin_pool            | Shortcut for creating a new `lvm_thin_pool` definition (the logical volumes will be created in the order they are declared)                                                |                                   |
+Property               | Description                                                                                                                                                                | Example                           | Default
+---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------
+name                   | (required) Name of the volume group                                                                                                                                        | <tt>'bacon'</tt>                  |
+physical_volumes       | (required) The device or list of devices to use as physical volumes (if they haven't already been initialized as physical volumes, they will be initialized automatically) | <tt>['/dev/sda', '/dev/sdb']</tt> |
+physical_extent_size   | The physical extent size for the volume group                                                                                                                              |                                   |
+logical_volume         | Shortcut for creating a new `lvm_logical_volume` definition (the logical volumes will be created in the order they are declared)                                           |                                   |
+wipe_signatures        | Force the creation of the Volume Group, even if `lvm` detects existing non-LVM data on disk                                                                                | `true`                            | `false`
+thin_pool              | Shortcut for creating a new `lvm_thin_pool` definition (the logical volumes will be created in the order they are declared)                                                |                                   |
+ignore_skipped_cluster | Continue execution even if `lvm` detects skipped clustered volume groups                                                | `true`                            | `false`
 
 #### Examples
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['lvm']['chef-ruby-lvm']['version'] = '0.3.0'
+default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
 default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.3'
 default['lvm']['cleanup_old_gems'] = true
 default['lvm']['rubysource'] = 'https://rubygems.org'

--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -48,7 +48,7 @@ class Chef
         require_lvm_gems
         install_filesystem_deps
 
-        lvm = LVM::LVM.new
+        lvm = LVM::LVM.new(lvm_options)
         name = new_resource.name
         group = new_resource.group
         fs_type = new_resource.filesystem
@@ -130,7 +130,7 @@ class Chef
       # Action to resize LV to specified size
       def action_resize
         require_lvm_gems
-        lvm = LVM::LVM.new
+        lvm = LVM::LVM.new(lvm_options)
         name = new_resource.name
         group = new_resource.group
 
@@ -217,6 +217,10 @@ class Chef
       end
 
       protected
+
+      def lvm_options
+        new_resource.ignore_skipped_cluster ? { additional_arguments: '--ignoreskippedcluster' } : {}
+      end
 
       def install_filesystem_deps
         if platform_family?('suse') && /^ext/.match(new_resource.filesystem)

--- a/libraries/provider_lvm_volume_group.rb
+++ b/libraries/provider_lvm_volume_group.rb
@@ -55,7 +55,7 @@ class Chef
         # The notifications should be set if the lvm_volume_group or any of its sub lvm_logical_volume resources are
         # updated.
 
-        lvm = LVM::LVM.new
+        lvm = LVM::LVM.new(lvm_options)
         # Create the volume group
         create_volume_group(lvm, physical_volume_list, name)
 
@@ -69,7 +69,7 @@ class Chef
         require_lvm_gems
         name = new_resource.name
         physical_volume_list = [new_resource.physical_volumes].flatten
-        lvm = LVM::LVM.new
+        lvm = LVM::LVM.new(lvm_options)
 
         # verify that the volume group is valid
         raise("VG #{name} is not a valid volume group") if lvm.volume_groups[name].nil?
@@ -103,6 +103,10 @@ class Chef
       end
 
       private
+
+      def lvm_options
+        new_resource.ignore_skipped_cluster ? { additional_arguments: '--ignoreskippedcluster' } : {}
+      end
 
       def create_mount_resource(physical_volume_list)
         physical_volume_list.select { |pv| ::File.exist?(pv) }.each do |pv|

--- a/libraries/resource_lvm_logical_volume.rb
+++ b/libraries/resource_lvm_logical_volume.rb
@@ -164,6 +164,21 @@ class Chef
           default: false
         )
       end
+
+      # Attribute: ignore_skipped_cluster -
+      #
+      # @param arg [Boolean] whether to ignore skipped cluster VGs during LVM commands
+      #
+      # @return [Boolean] the ignore_skipped_cluster setting
+      #
+      def ignore_skipped_cluster(arg = nil)
+        set_or_return(
+          :ignore_skipped_cluster,
+          arg,
+          kind_of: [TrueClass, FalseClass],
+          default: false
+        )
+      end
     end
   end
 end

--- a/libraries/resource_lvm_volume_group.rb
+++ b/libraries/resource_lvm_volume_group.rb
@@ -142,6 +142,21 @@ class Chef
         @logical_volumes << volume
         volume
       end
+
+      # Attribute: ignore_skipped_cluster -
+      #
+      # @param arg [Boolean] whether to ignore skipped cluster VGs during LVM commands
+      #
+      # @return [Boolean] the ignore_skipped_cluster setting
+      #
+      def ignore_skipped_cluster(arg = nil)
+        set_or_return(
+          :ignore_skipped_cluster,
+          arg,
+          kind_of: [TrueClass, FalseClass],
+          default: false
+        )
+      end
     end
   end
 end

--- a/resources/physical_volume.rb
+++ b/resources/physical_volume.rb
@@ -22,11 +22,14 @@ property :volume_name, String, name_property: true
 # whether to automatically wipe any preexisting signatures
 property :wipe_signatures, [TrueClass, FalseClass], default: false
 
+# whether to ignore skipped cluster VGs during LVM commands
+property :ignore_skipped_cluster, [TrueClass, FalseClass], default: false
+
 # The create action
 #
 action :create do
   require_lvm_gems
-  lvm = LVM::LVM.new
+  lvm = LVM::LVM.new(lvm_options)
   if lvm.physical_volumes[new_resource.name].nil?
     yes_flag = new_resource.wipe_signatures == true ? '--yes' : ''
 
@@ -38,7 +41,7 @@ end
 
 action :resize do
   require_lvm_gems
-  lvm = LVM::LVM.new
+  lvm = LVM::LVM.new(lvm_options)
   pv = lvm.physical_volumes.select do |pvs|
     pvs.name == new_resource.name
   end
@@ -69,4 +72,8 @@ end
 
 action_class do
   include LVMCookbook
+
+  def lvm_options
+    new_resource.ignore_skipped_cluster ? { additional_arguments: '--ignoreskippedcluster' } : {}
+  end
 end

--- a/test/fixtures/cookbooks/test/recipes/create.rb
+++ b/test/fixtures/cookbooks/test/recipes/create.rb
@@ -93,6 +93,7 @@ lvm_logical_volume 'test' do
   size '50%VG'
   filesystem 'ext3'
   mount_point '/mnt/test'
+  ignore_skipped_cluster true
 end
 
 # Creates a small logical volume


### PR DESCRIPTION
Signed-off-by: Matthew Newell <matthew.newell@cerner.com>

### Description

This change adds the `ignore_skipped_cluster` property to all resources that initialize the LVM object. This allows LVM resources such as VGs, LVs, or PVs to be managed via Chef even if skipped clustered VGs exist. This is set to false by default preserving existing functionality.

### Issues Resolved

#156 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
