### PR TITLE
Fix unable to extend thin pool metadata size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,46 +511,13 @@ Action  | Description
 
 #### Properties
 
-<table>
-  <tr>
-    <th>Attribute</th>
-    <th>Description</th>
-    <th>Example</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td>name</td>
-    <td>(name attribute) Name of the thin pool metadata volume</td>
-    <td><tt>bacon</tt></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>group</td>
-    <td>(required) Name of volume group in which thin pool metadata volume exist.</td>
-    <td><tt>bits</tt></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>pool</td>
-    <td>(required) Name of thin pool volume in which thin pool metadata volume exist.</td>
-    <td><tt>bits</tt></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>size</td>
-    <td>(required) Size of the thin pool metadata volume.
-      <ul>
-        <li>It can be the size of the volume with units (k, K, m, M, g, G, t, T)</li>
-      </ul>
-    </td>
-    <td>
-      <ul>
-        <tt>2M</tt>
-      </ul>
-    </td>
-    <td></td>
-  </tr>
-</table>
+
+Property            | Description                                                                   | Example  | Default
+--------------------| ------------------------------------------------------------------------------| -------- | -------
+name                | (name attribute) Name of the thin pool metadata volume                        | bacon    |
+group               | (required) Name of volume group in which thin pool metadata volume exist.     | bits     |
+pool                | (required) Name of thin pool volume in which thin pool metadata volume exist. | bits     |
+size                | (required) Size of the thin pool metadata volume. It can be the size of the volume with units (k, K, m, M, g, G, t, T) | 2M |
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -499,6 +499,70 @@ lvm_volume_group 'vg00' do
 end
 ```
 
+### lvm_thin_pool_meta_data
+
+Manages LVM thin pool metadata size.
+
+#### Actions
+
+Action  | Description
+------- | ---------------------------------------------------------------
+:resize | Resize an existing thin pool metadata volume
+
+#### Properties
+
+<table>
+  <tr>
+    <th>Attribute</th>
+    <th>Description</th>
+    <th>Example</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>(name attribute) Name of the thin pool metadata volume</td>
+    <td><tt>bacon</tt></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>group</td>
+    <td>(required) Name of volume group in which thin pool metadata volume exist.</td>
+    <td><tt>bits</tt></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>pool</td>
+    <td>(required) Name of thin pool volume in which thin pool metadata volume exist.</td>
+    <td><tt>bits</tt></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>size</td>
+    <td>(required) Size of the thin pool metadata volume.
+      <ul>
+        <li>It can be the size of the volume with units (k, K, m, M, g, G, t, T)</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <tt>2M</tt>
+      </ul>
+    </td>
+    <td></td>
+  </tr>
+</table>
+
+#### Examples
+
+```ruby
+lvm_thin_pool_meta_data 'lv-thin-pool_tmeta' do
+  group       'vg00'
+  pool        'lv-thin-pool'q
+  size        '2M'
+  action      :resize
+end
+```
+
 ## Usage
 
 Include the default recipe in your run list on a node, in a role, or in another recipe:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -39,3 +39,9 @@ suites:
     run_list:
       - recipe[test::create_thin]
       - recipe[test::resize_thin]
+  - name: resize_thin_pool_meta_data
+    excludes:
+    - debian-8
+    run_list:
+      - recipe[test::create_thin]
+      - recipe[test::resize_thin_pool_meta_data]

--- a/libraries/provider_lvm_thin_pool_meta_data.rb
+++ b/libraries/provider_lvm_thin_pool_meta_data.rb
@@ -1,0 +1,110 @@
+#
+# Cookbook:: lvm
+# Library:: provider_lvm_thin_pool_meta_data
+#
+# Copyright:: 2016-2017, Ontario Systems, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/provider'
+require 'chef/mixin/shell_out'
+require 'chef/dsl/recipe'
+require File.join(File.dirname(__FILE__), 'lvm')
+
+class Chef
+  class Provider
+    # The provider for lvm_thin_volume resource
+    #
+    class LvmThinPoolMetaData < Chef::Provider
+      include Chef::DSL::Recipe
+      include Chef::Mixin::ShellOut
+      include LVMCookbook
+
+      # Loads the current resource attributes
+      #
+      # @return [Chef::Resource::LvmThinPoolMetaData] the lvm_thin_pool_meta_data resource
+      #
+      def load_current_resource
+        @current_resource ||= Chef::Resource::LvmThinPoolMetaData.new(@new_resource.name)
+        @current_resource
+      end
+
+      def action_resize
+        require_lvm_gems
+        lvm = LVM::LVM.new
+        name = new_resource.name
+        group = new_resource.group
+        pool = new_resource.pool
+        vg = lvm.volume_groups[group]
+
+        # if doing a resize make sure that the volume exists before doing anything
+        raise("Error volume group #{group} does not exist") if vg.nil?
+        
+        lv = vg.logical_volumes.select do |lvs|
+          lvs.name == pool
+        end
+
+        # make sure that the thin pool / volume specified exists in the VG specified.
+        raise("Error logical volume (thin pool) #{name} does not exist") if lv.empty?
+
+        lv_metadata = vg.logical_volumes.select do |lvs|
+          lvs.metadata_lv == "[#{name}]"
+        end
+
+        # make sure that the thin pool metadata specified exists in the VG specified
+        raise("Error logical volume thin pool metadata volume #{name} does not exist") if lv_metadata.empty?      
+
+        lv_metadata = lv_metadata.first
+        pe_size = vg.extent_size.to_i
+        lv_metadata_size_cur = lv_metadata.metadata_size.to_i / pe_size
+
+        lv_metadata_size = new_resource.size
+        lv_metadata_size_req = case lv_metadata_size
+                        when /^(\d+)(k|K)$/
+                          (Regexp.last_match[1].to_i * 1024) / pe_size
+                        when /^(\d+)(m|M)$/
+                          (Regexp.last_match[1].to_i * 1_048_576) / pe_size
+                        when /^(\d+)(g|G)$/
+                          (Regexp.last_match[1].to_i * 1_073_741_824) / pe_size
+                        when /^(\d+)(t|T)$/
+                          (Regexp.last_match[1].to_i * 1_099_511_627_776) / pe_size
+                        when /^(\d+)$/
+                          Regexp.last_match[1].to_i
+                        else
+                          raise("Invalid size #{Regexp.last_match[1]} for lvm resize")
+                        end
+
+        if lv_metadata_size_cur >= lv_metadata_size_req
+          Chef::Log.debug "Logical volume thin pool metadata #{lv_metadata.name} in volume group #{group} already at requested size"
+        else        
+          command = resize_command(new_resource.size)
+          Chef::Log.debug "Running command: #{command}"
+          output = lvm.raw command
+          Chef::Log.debug "Command output: #{output}"
+          # broadcast that we did a resize
+          new_resource.updated_by_last_action true
+        end
+      end
+
+      protected      
+
+      def resize_command(lv_size_req)
+        name = new_resource.name
+        group = new_resource.group
+        pool = new_resource.pool        
+        "lvextend --poolmetadatasize #{lv_size_req} #{group}/#{pool}"
+      end
+    end
+  end
+end

--- a/libraries/resource_lvm_thin_pool_meta_data.rb
+++ b/libraries/resource_lvm_thin_pool_meta_data.rb
@@ -1,0 +1,78 @@
+#
+# Cookbook:: lvm
+# Library:: resource_lvm_thin_pool_meta_data
+#
+# Copyright:: 2016-2017, Ontario Systems, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+require_relative 'base_resource_logical_volume'
+
+class Chef
+  class Resource
+    # The lvm_thin_pool_meta_data resource
+    #
+    # A thin pool metadata is a thin pool's metadata logical volume
+    class LvmThinPoolMetaData < Chef::Resource::BaseLogicalVolume
+      resource_name :lvm_thin_pool_meta_data
+
+      default_action :resize
+      allowed_actions :resize
+
+      # Initializes the lvm_thin_pool_meta_data resource
+      #
+      # @param name [String] name of the resource
+      # @param run_context [Chef::RunContext] the run context of chef run
+      #
+      # @return [Chef::Resource::LvmThinPoolMetaData] the lvm_thin_pool_meta_data resource
+      #
+      def initialize(name, run_context = nil)
+        super
+        @provider = Chef::Provider::LvmThinPoolMetaData
+      end
+
+      # Attribute: pool - The name of the thin pool logical volume in which this metadata volume exist
+      #
+      # @param arg [String] The name of the thin pool logical volume in which this metadata volume exist
+      #
+      # @return [String] The name of the thin pool logical volume in which this metadata volume exist
+      #
+      def pool(arg = nil)
+        set_or_return(
+          :pool,
+          arg,
+          kind_of: String,
+          required: true
+        )
+      end
+
+      # Attribute: size - the size of thin pool metadata logical volume
+      #
+      # @param arg [String] the size of thin pool metadata logical volume
+      #
+      # @return [String] the size of thin pool metadata logical volume
+      #
+      def size(arg = nil)
+        set_or_return(
+          :size,
+          arg,
+          kind_of: String,
+          regex: /^(\d+[kKmMgGtT]|\d+)$/,
+          required: true
+        )
+      end
+    end
+  end
+end

--- a/spec/lvm_test/resize_thin_pool_meta_data_spec.rb
+++ b/spec/lvm_test/resize_thin_pool_meta_data_spec.rb
@@ -1,0 +1,35 @@
+
+require 'spec_helper'
+
+describe 'test::resize_thin' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(platform: platform, version: version).converge('test::resize_thin_pool_meta_data')
+  end
+
+  describe 'on Ubuntu 16.04' do
+    let(:platform) { 'ubuntu' }
+    let(:version) { '16.04' }
+
+    it 'resizes logical volume' do
+      expect(chef_run).to resize_lvm_thin_pool_meta_data('lv-thin_tmeta')
+    end
+  end
+
+  describe 'on RHEL 7' do
+    let(:platform) { 'centos' }
+    let(:version) { '7.3.1611' }
+
+    it 'resizes logical volume' do
+      expect(chef_run).to resize_lvm_thin_pool_meta_data('lv-thin_tmeta')
+    end
+  end
+
+  describe 'on Amazon Linux' do
+    let(:platform) { 'amazon' }
+    let(:version) { '2016.03' }
+
+    it 'resizes logical volume' do
+      expect(chef_run).to resize_lvm_thin_pool_meta_data('lv-thin_tmeta')
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/create.rb
+++ b/test/fixtures/cookbooks/test/recipes/create.rb
@@ -42,7 +42,8 @@ devices = [
   '/dev/loop7',
 ]
 
-loop_devices devices do
+loop_devices 'loop_devices' do
+  devices devices
   action :create
 end
 

--- a/test/fixtures/cookbooks/test/recipes/create_thin.rb
+++ b/test/fixtures/cookbooks/test/recipes/create_thin.rb
@@ -28,7 +28,8 @@ devices = [
   '/dev/loop3',
 ]
 
-loop_devices devices do
+loop_devices 'loop_devices' do
+  devices devices
   action :create
 end
 

--- a/test/fixtures/cookbooks/test/recipes/resize_thin_pool_meta_data.rb
+++ b/test/fixtures/cookbooks/test/recipes/resize_thin_pool_meta_data.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook:: test
+# Recipe:: resize_thin_pool_meta_data
+#
+# Copyright:: 2016-2017, Ontario Systems, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distribued on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Resize a thin volume
+# Volume was created in create_thin recipe
+#
+lvm_thin_pool_meta_data 'lv-thin_tmeta_data_resize' do
+  action [:resize]
+  name 'lv-thin_tmeta'
+  group 'vg-test'
+  pool 'lv-thin'
+  size '128M'
+  filesystem 'ext3'
+  mount_point '/mnt/thin1'
+end

--- a/test/fixtures/cookbooks/test/resources/loop_devices.rb
+++ b/test/fixtures/cookbooks/test/resources/loop_devices.rb
@@ -3,14 +3,12 @@ resource_name :loop_devices
 property :devices, Array, name_property: true
 
 action :create do
-  def self.create_loop_devices(devices)
-    Array(devices).each do |device|
-      next if shell_out!('pvs').stdout.match?(device)
-      converge_by "create loop device #{device}" do
-        num = device.slice(/\d+/)
-        shell_out!("dd if=/dev/zero of=/vfile#{num} bs=2048 count=65536")
-        shell_out!("losetup #{device} /vfile#{num}")
-      end
+  Array(new_resource.devices).each do |device|
+    next if shell_out!('pvs').stdout.match?(device)
+    converge_if_changed do
+      num = device.slice(/\d+/)
+      shell_out!("dd if=/dev/zero of=/vfile#{num} bs=2048 count=65536")
+      shell_out!("losetup #{device} /vfile#{num}")
     end
   end
 end

--- a/test/integration/resize_thin_pool_meta_data/bats/verify_resize_thin_pool_meta_data.bats
+++ b/test/integration/resize_thin_pool_meta_data/bats/verify_resize_thin_pool_meta_data.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "resizes the thin pool metadata volume 'lv-thin-pool_tmeta' to 128m" {
+  metadata_size="$(lvs --options meta_data_lv,lv_metadata_size|awk '/lv-thin_tmeta/ {print $2}')"
+  [ "$metadata_size" == "128.00m" ]
+}


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description
Allows user to extend metadata size for LVM thinpools using LVM cookbook.

### Issues Resolved
Fixes #151 
### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
