### PR TITLE
adding logic to handle RAW volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the lvm cookbook.
 
+## 4.4.0 (2018-08-10)
+
+- Added 'lv_params' to be handled as part of lvm_logical_volume :resize, as it was available only for :create - to resolve GH-159
+- Added logic to not pass '--resizefs' if the filesystem is 'RAW'
+- Added missing documentation on the hidden option of sending 'lv_params' to the resource for both :create and :resize
+
 ## 4.3.0 (2018-07-31)
 
 - Added new lvm_thin_pool_meta_data resource

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ Action  | Description
     <td><tt>true</tt></td>
     <td><tt>false</tt></td>
   </tr>
+  <tr>
+    <td>lv_params</td>
+    <td>Optional parameters to be passed to LVM</td>
+    <td><tt>'--nofsck'</tt></td>
+    <td><tt></tt></td>
+  </tr>
 </table>
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Manages LVM logical volumes.
 Action  | Description
 ------- | --------------------------------------
 :create | (default) Creates a new logical volume
-:resize | Resize an existing logical volume
+:resize | Resize an existing logical volume (resizing only handles extending existing, this action will not shrink volumes due to the 'lvextend' command being passed)
 
 #### Parameters
 <table>
@@ -225,7 +225,7 @@ Manages LVM thin pools (which are simply logical volumes created with the --thin
   </tr>
   <tr>
     <td>:resize</td>
-    <td>Resize an existing thin pool logical volume</td>
+    <td>Resize an existing thin pool logical volume (resizing only handles extending existing, this action will not shrink volumes due to the 'lvextend' command being passed)</td>
   </tr>
 </table>
 
@@ -365,7 +365,7 @@ Manages LVM thin volumes (which are simply logical volumes created with the --th
   </tr>
   <tr>
     <td>:resize</td>
-    <td>Resize an existing thin logical volume</td>
+    <td>Resize an existing thin logical volume (resizing only handles extending existing, this action will not shrink volumes due to the 'lvextend' command being passed)</td>
   </tr>
 </table>
 
@@ -521,7 +521,7 @@ Manages LVM thin pool metadata size.
 
 Action  | Description
 ------- | ---------------------------------------------------------------
-:resize | Resize an existing thin pool metadata volume
+:resize | Resize an existing thin pool metadata volume (resizing only handles extending existing, this action will not shrink volumes due to the 'lvextend' command being passed)
 
 #### Properties
 

--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ lvm_thin_pool_meta_data 'lv-thin-pool_tmeta' do
 end
 ```
 
+
 ## Usage
 
 Include the default recipe in your run list on a node, in a role, or in another recipe:

--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -266,12 +266,19 @@ class Chef
         name = new_resource.name
         group = new_resource.group
         device_name = "/dev/mapper/#{to_dm_name(group)}-#{to_dm_name(name)}"
-        resize_fs = '--resizefs'
+        resize_fs =
+          case new_resource.filesystem
+          when /raw/i
+            ''
+          else
+            '--resizefs'
+          end
         stripes = new_resource.stripes ? "--stripes #{new_resource.stripes}" : ''
         stripe_size = new_resource.stripe_size ? "--stripesize #{new_resource.stripe_size}" : ''
         mirrors = new_resource.mirrors ? "--mirrors #{new_resource.mirrors}" : ''
+        lv_params = new_resource.lv_params
 
-        "lvextend -l #{lv_size_req} #{resize_fs} #{stripes} #{stripe_size} #{mirrors} #{device_name}"
+        "lvextend -l #{lv_size_req} #{resize_fs} #{stripes} #{stripe_size} #{mirrors} #{device_name} #{lv_params}"
       end
 
       private

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs and manages Logical Volume Manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.3.0'
+version '4.4.0'
 
 %w(amazon centos fedora freebsd oracle redhat scientific suse ubuntu).each do |os|
   supports os

--- a/spec/lvm_test/resize_spec.rb
+++ b/spec/lvm_test/resize_spec.rb
@@ -20,6 +20,14 @@ describe 'test::resize' do
     it 'Resize logical volume' do
       expect(chef_run).to resize_lvm_logical_volume('small_resize')
     end
+
+    it 'Create RAW logical volume' do
+      expect(chef_run).to create_lvm_logical_volume('small_resize_raw')
+    end
+
+    it 'Resize RAW logical volume' do
+      expect(chef_run).to resize_lvm_logical_volume('small_resize_raw')
+    end
   end
 
   context 'on RHEL 7' do
@@ -41,6 +49,14 @@ describe 'test::resize' do
     it 'Resize logical volume' do
       expect(chef_run).to resize_lvm_logical_volume('small_resize')
     end
+
+    it 'Create RAW logical volume' do
+      expect(chef_run).to create_lvm_logical_volume('small_resize_raw')
+    end
+
+    it 'Resize RAW logical volume' do
+      expect(chef_run).to resize_lvm_logical_volume('small_resize_raw')
+    end
   end
 
   context 'on Amazon Linux' do
@@ -61,6 +77,14 @@ describe 'test::resize' do
 
     it 'Resize logical volume' do
       expect(chef_run).to resize_lvm_logical_volume('small_resize')
+    end
+
+    it 'Create RAW logical volume' do
+      expect(chef_run).to create_lvm_logical_volume('small_resize_raw')
+    end
+
+    it 'Resize RAW logical volume' do
+      expect(chef_run).to resize_lvm_logical_volume('small_resize_raw')
     end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/resize.rb
+++ b/test/fixtures/cookbooks/test/recipes/resize.rb
@@ -121,6 +121,27 @@ lvm_logical_volume 'percent_noresize_test' do
   mount_point '/mnt/percent_noresize'
 end
 
+# Create a LV to resize for later option test
+# RAW volume (no filesystem)
+#
+lvm_logical_volume 'small_resize_raw' do
+  action :create
+  group 'vg-test'
+  size '8M'
+end
+
+# Resize a lv based off explicit size using an option parameter
+# RAW volume (no filesystem)
+#
+lvm_logical_volume 'small_resize_raw_test' do
+  action :resize
+  name 'small_resize_raw'
+  group 'vg-test'
+  size '16M'
+  filesystem 'RAW'
+  lv_params '--nofsck'
+end
+
 # Resize a lv based off percent
 # Should stay the same size
 #

--- a/test/integration/resize/bats/verify_resize.bats
+++ b/test/integration/resize/bats/verify_resize.bats
@@ -32,8 +32,15 @@ export PATH=$PATH:/sbin:/usr/sbin
   [ "$lvsize" -ge "$num_extents" ]
 }
 
+@test "creates the raw logical volume at 8MB and resizes to 16MB" {
+  # 8MB LV size / 4MB default extent size
+  num_extents="4"
+  lvsize="$(lvdisplay /dev/mapper/vg--test-small_resize_raw|awk '/Current LE/ {print $3}')"
+  [ "$lvsize" -ge "$num_extents" ]
+}
+
 @test "creates and resizes a logical volume that fills the VG" {
-  num_extents="36"
+  num_extents="32"
   lvsize="$(lvdisplay /dev/mapper/vg--test-remainder_resize|awk '/Current LE/ {print $3}')"
   [ "$lvsize" -ge "$num_extents" ]
 }


### PR DESCRIPTION
Signed-off-by: ChrisA.Walker <ChrisA.Walker@target.com>

### Description

- Added 'lv_params' to be handled as part of lvm_logical_volume :resize, as it was available only for :create - to resolve GH-159
- Added logic to not pass '--resizefs' if the filesystem is 'RAW'
- Added missing documentation on the hidden option of sending 'lv_params' to the resource for both :create and :resize

### Issues Resolved

https://github.com/chef-cookbooks/lvm/issues/159
https://github.com/chef-cookbooks/lvm/issues/140
https://github.com/chef-cookbooks/lvm/issues/111
https://github.com/chef-cookbooks/lvm/issues/110

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
