### PR TITLE
Update the attributes gem version from 0.2.5 to 0.2.6

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,6 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.5'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.6'
 default['lvm']['cleanup_old_gems'] = true
 default['lvm']['rubysource'] = 'https://rubygems.org'


### PR DESCRIPTION
### Description

Update the attributes gem version from 0.2.5 to 0.2.6

### Issues Resolved

[Unable to load lvm attributes [lvs.yaml] for version [2.02.180(2)]](https://github.com/chef/chef-ruby-lvm-attrib/issues/7)

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
