### PR TITLE
bumping chef-ruby-lvm-attrib to 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the lvm cookbook.
 
+## 4.5.2 (2018-11-01)
+
+- Update the attributes gem version from 0.2.5 to 0.2.6
+
 ## 4.5.1 (2018-11-01)
 
 - Update the attributes gem version from 0.2.3 to 0.2.5

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,6 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.5'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.6'
 default['lvm']['cleanup_old_gems'] = true
 default['lvm']['rubysource'] = 'https://rubygems.org'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs and manages Logical Volume Manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.5.1'
+version '4.5.2'
 
 %w(amazon centos fedora freebsd oracle redhat scientific suse ubuntu).each do |os|
   supports os


### PR DESCRIPTION
Signed-off-by: ChrisA.Walker <ChrisA.Walker@target.com>

### Description

Updates the chef-ruby-lvm-attrib version to the latest available (0.2.6).

### Issues Resolved

https://github.com/chef-cookbooks/lvm/issues/168
https://github.com/chef-cookbooks/lvm/issues/166

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
