### PR TITLE
Add support for the ignore_skipped_cluster property, fixes #170

### DIFF
--- a/libraries/resource_lvm_thin_volume.rb
+++ b/libraries/resource_lvm_thin_volume.rb
@@ -73,6 +73,21 @@ class Chef
           required: true
         )
       end
+
+      # Attribute: ignore_skipped_cluster -
+      #
+      # @param arg [Boolean] whether to ignore skipped cluster VGs during LVM commands
+      #
+      # @return [Boolean] the ignore_skipped_cluster setting
+      #
+      def ignore_skipped_cluster(arg = nil)
+        set_or_return(
+          :ignore_skipped_cluster,
+          arg,
+          kind_of: [TrueClass, FalseClass],
+          default: false
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: michael.sgarbossa <msgarbossa@cvs.com>

### Description

Add support for the ignore_skipped_cluster property (copied from resource_lvm_logical_volume.rb)

### Issues Resolved

#170

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
