### PR TITLE
Bump chef-ruby-lvm-attrib to 0.2.8 from 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the lvm cookbook.
 
+## 4.5.4 (2019-08-20)
+
+- Update the attributes gem version from 0.2.6 to 0.2.8
+
 ## 4.5.3 (2018-12-26)
 
 - Add support for the ignore_skipped_cluster property, fixes #170 - [msgarbossa](https://github.com/msgarbossa)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,6 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.6'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.8'
 default['lvm']['cleanup_old_gems'] = true
 default['lvm']['rubysource'] = 'https://rubygems.org'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs and manages Logical Volume Manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.5.3'
+version '4.5.4'
 
 %w(amazon centos fedora freebsd oracle redhat scientific suse ubuntu).each do |os|
   supports os


### PR DESCRIPTION
Signed-off-by: Matthew Newell <matthew.newell@cerner.com>

### Description

This change increases the chef-ruby-lvm-attrib gem version from 0.2.6 to 0.2.8 to allow for support of later versions of LVM.

### Issues Resolved

Fixes #174 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
