### PR TITLE
Remove the legacy gem cleanup logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs lvm2 package and includes resources for managing LVM.
 
 ## Note on LVM gems
 
-This cookbook has used multiple variants of the ruby-lvm and ruby-lvm-attrib gems for interacting with LVM. Most recently we used di-ruby-lvm and di-ruby-lvm-attrib gems, which are no longer being maintained. As of the 4.0 release this cookbook uses new Chef maintained gems: chef-ruby-lvm and chef-ruby-lvm-attrib. The cookbook will first remove the old gems before load/installing the new gems, in order to prevent gem conflicts. If you previously used attributes to control the version of the gems to install, you will need to update to the latest attribute names to maintain that functionality.
+This cookbook has used multiple variants of the ruby-lvm and ruby-lvm-attrib gems for interacting with LVM. Most recently we used di-ruby-lvm and di-ruby-lvm-attrib gems, which are no longer being maintained. As of the 4.0 release this cookbook uses new Chef maintained gems: chef-ruby-lvm and chef-ruby-lvm-attrib. Previous versions of this cookbook supported cleaning those gems up for approximetly 3 years. At this point you'll need to remove those gems yourself if they're still present as the namespaces will conflict. If you previously used attributes to control the version of the gems to install, you will need to update to the latest attribute names to maintain that functionality.
 
 ## Requirements
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,5 +19,4 @@
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
 default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.1'
-default['lvm']['cleanup_old_gems'] = true
 default['lvm']['rubysource'] = 'https://rubygems.org'

--- a/libraries/lvm.rb
+++ b/libraries/lvm.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2016-2019, Chef Software, Inc.
+# Copyright:: Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,24 +18,6 @@
 module LVMCookbook
   def require_lvm_gems
     return if defined?(LVM)
-
-    Chef::Log.warn("The previous di-ruby-lvm and di-ruby-lvm-attrib gems have been replaced with chef maintained forks. You have set the legacy attributes (node['lvm']['di-ruby-lvm']/node['lvm']['di-ruby-lvm-attrib']) for pinning installed gem versions. You will need to remove these attributes and instead set the new chef varients. See the attributes file for the latest attributes.") if node['lvm']['di-ruby-lvm'] || node['lvm']['di-ruby-lvm-attrib']
-
-    if node['lvm']['cleanup_old_gems']
-      chef_gem "#{new_resource.name}_di-ruby-lvm-attrib_removal" do
-        package_name 'di-ruby-lvm-attrib'
-        action :remove
-        compile_time true
-        source node['lvm']['rubysource']
-      end
-
-      chef_gem "#{new_resource.name}_di-ruby-lvm_removal" do
-        package_name 'di-ruby-lvm'
-        action :remove
-        compile_time true
-        source node['lvm']['rubysource']
-      end
-    end
 
     # require attribute specified gems
     gem 'chef-ruby-lvm-attrib', node['lvm']['chef-ruby-lvm-attrib']['version']

--- a/test/fixtures/cookbooks/test/recipes/create.rb
+++ b/test/fixtures/cookbooks/test/recipes/create.rb
@@ -19,15 +19,6 @@
 
 apt_update 'update'
 
-# install the old gems to make sure the uninstall works
-chef_gem 'di-ruby-lvm' do
-  compile_time true
-end
-
-chef_gem 'di-ruby-lvm-attrib' do
-  compile_time true
-end
-
 include_recipe 'lvm'
 
 # The test device to use

--- a/test/fixtures/cookbooks/test/recipes/remove.rb
+++ b/test/fixtures/cookbooks/test/recipes/remove.rb
@@ -19,17 +19,6 @@
 
 apt_update 'update'
 
-# install the old gems to make sure the uninstall works
-chef_gem 'di-ruby-lvm' do
-  compile_time true
-  not_if '/opt/chef/embedded/bin/gem list | grep "chef-ruby-lvm ""'
-end
-
-chef_gem 'di-ruby-lvm-attrib' do
-  compile_time true
-  not_if '/opt/chef/embedded/bin/gem list | grep chef-ruby-lvm-attrib'
-end
-
 include_recipe 'lvm'
 
 # The test device to use


### PR DESCRIPTION
We've been cleaning up these gems for 3 years now. A new Chef Infra Client install will nuke the directory anyways so there's really no reason to continue this costly cleanup on each Chef Infra Client run.

Signed-off-by: Tim Smith <tsmith@chef.io>