### PR TITLE
Update the attributes gem version from 0.3.1 to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the lvm cookbook.
 
+## 5.0.1 (2020-05-27)
+
+- Update the attributes gem version from 0.3.1 to 0.3.2
+
 ## 5.0.0 (2020-05-01)
 
 The 5.0 release of this cookbook no longer cleans up the legacy di-ruby-lvm-attrib and di-ruby-lvm gems. These gems were replaced and the cleanup was added ~3 years ago. Any upgrade to this cookbook or to the Chef Infra Client would remove the legacy gems. If you are trying to upgrade from a VERY old version of this cookbook to current you'll either need to perform that cleanup by hand in a wrapper cookbook or you'll want to use the 4.x release first to perform the cleanup.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.1'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.2'
 default['lvm']['rubysource'] = 'https://rubygems.org'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs and manages Logical Volume Manager'
-version '5.0.0'
+version '5.0.1'
 %w(amazon centos fedora freebsd oracle redhat scientific suse ubuntu).each do |os|
   supports os
 end


### PR DESCRIPTION
 CHANGELOG.md          | 4 ++++
 attributes/default.rb | 2 +-
 metadata.rb           | 2 +-
 3 files changed, 6 insertions(+), 2 deletions(-)

Signed-off-by: gael martinez <gael.martinez@gmail.com>

### Description

Update the attributes gem version from 0.3.1 to 0.3.2 to support RHEL 8.2

### Issues Resolved

Fixes #181 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>