### PR TITLE
Support chef 16 and ubuntu 20.04

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.2'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.3'
 default['lvm']['rubysource'] = 'https://rubygems.org'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,6 +17,7 @@ platforms:
   - name: opensuse-leap-15
   - name: ubuntu-16.04
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
   - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux

--- a/libraries/base_resource_logical_volume.rb
+++ b/libraries/base_resource_logical_volume.rb
@@ -26,6 +26,9 @@ class Chef
     class BaseLogicalVolume < Chef::Resource
       include Chef::DSL::Recipe
 
+      resource_name :lvm_volume_group
+      provides :lvm_volume_group
+
       # Initializes a BaseLogicalVolume object. This class is only meant to
       # be used as a base class for other resources.
       #

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe 'lvm::default on Ubuntu 16.04' do
+describe 'lvm::default on Ubuntu 20.04' do
   cached(:chef_run_ubuntu) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge('lvm::default')
+    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '20.04').converge('lvm::default')
   end
 
   it 'installs lvm2' do

--- a/spec/lvm_test/create_spec.rb
+++ b/spec/lvm_test/create_spec.rb
@@ -13,9 +13,9 @@ describe 'test::create' do
     allow(File).to receive(:stat).with('/mnt/small').and_return(0100555)
   end
 
-  context 'on Ubuntu 16.04' do
+  context 'on Ubuntu 20.04' do
     let(:platform) { 'ubuntu' }
-    let(:version) { '16.04' }
+    let(:version) { '20.04' }
 
     it 'Create volume group' do
       expect(chef_run).to create_lvm_volume_group('vg-test')

--- a/spec/lvm_test/create_thin_spec.rb
+++ b/spec/lvm_test/create_thin_spec.rb
@@ -12,9 +12,9 @@ describe 'test::create_thin' do
     allow(File).to receive(:stat).with('/mnt/small').and_return(0o100555)
   end
 
-  context 'on Ubuntu 16.04' do
+  context 'on Ubuntu 20.04' do
     let(:platform) { 'ubuntu' }
-    let(:version) { '16.04' }
+    let(:version) { '20.04' }
 
     it 'Create volume group' do
       expect(chef_run).to create_lvm_volume_group('vg-data')

--- a/spec/lvm_test/remove_spec.rb
+++ b/spec/lvm_test/remove_spec.rb
@@ -15,9 +15,9 @@ describe 'test::remove' do
     allow(File).to receive(:stat).with('/mnt/small').and_return(0100555)
   end
 
-  context 'on Ubuntu 16.04' do
+  context 'on Ubuntu 20.04' do
     let(:platform) { 'ubuntu' }
-    let(:version) { '16.04' }
+    let(:version) { '20.04' }
 
     %w(loop10 loop11 loop12 loop13).each do |device|
       it "Create physical volume: #{device}" do

--- a/spec/lvm_test/resize_spec.rb
+++ b/spec/lvm_test/resize_spec.rb
@@ -5,9 +5,9 @@ describe 'test::resize' do
     ChefSpec::SoloRunner.new(platform: platform, version: version).converge('test::resize')
   end
 
-  context 'on Ubuntu 16.04' do
+  context 'on Ubuntu 20.04' do
     let(:platform) { 'ubuntu' }
-    let(:version) { '16.04' }
+    let(:version) { '20.04' }
 
     it 'Resize physical volume' do
       expect(chef_run).to resize_lvm_physical_volume('/dev/loop0')

--- a/spec/lvm_test/resize_thin_pool_meta_data_spec.rb
+++ b/spec/lvm_test/resize_thin_pool_meta_data_spec.rb
@@ -5,9 +5,9 @@ describe 'test::resize_thin' do
     ChefSpec::SoloRunner.new(platform: platform, version: version).converge('test::resize_thin_pool_meta_data')
   end
 
-  describe 'on Ubuntu 16.04' do
+  describe 'on Ubuntu 20.04' do
     let(:platform) { 'ubuntu' }
-    let(:version) { '16.04' }
+    let(:version) { '20.04' }
 
     it 'resizes logical volume' do
       expect(chef_run).to resize_lvm_thin_pool_meta_data('lv-thin_tmeta')

--- a/spec/lvm_test/resize_thin_spec.rb
+++ b/spec/lvm_test/resize_thin_spec.rb
@@ -5,9 +5,9 @@ describe 'test::resize_thin' do
     ChefSpec::SoloRunner.new(platform: platform, version: version).converge('test::resize_thin')
   end
 
-  describe 'on Ubuntu 16.04' do
+  describe 'on Ubuntu 20.04' do
     let(:platform) { 'ubuntu' }
-    let(:version) { '16.04' }
+    let(:version) { '20.04' }
 
     it 'resizes logical volume' do
       expect(chef_run).to resize_lvm_thin_volume('thin_vol_1')


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
Updates the chef-ruby-lvm-attrib to 0.3.3 to work with ubuntu 20.04
Updates tests for Ubuntu 20.04
Adds resource_name and provides to the base_resource_logical_volume library for chef 16 support

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>