### PR TITLE
Chase upstream chef-ruby-lvm-attrib version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.3'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.5'
 default['lvm']['rubysource'] = 'https://rubygems.org'


### PR DESCRIPTION
Update to chef-ruby-lvm-attrib 0.3.5 to support latest RHEL7 lvm version.

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
Support RHEL7 with lvm2-libs-2.02.187-6.el7.rpm

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>