### PR TITLE
Use default Chef source for gems

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,4 +19,4 @@
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
 default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.5'
-default['lvm']['rubysource'] = 'https://rubygems.org'
+default['lvm']['rubysource'] = Chef::Config['rubygems_url']


### PR DESCRIPTION
Rather than default to rubygems.org by default, use the Chef default. This helps in the case the local admin has set Chef to point to a local mirror/repo instead. Seems this config option has been in Chef since 12.8.1 (https://github.com/chef/chef/commit/1d063284f755b996a6563d7210496afd716a9f2d), so seems safe.

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
This helps in the case the local admin has set Chef to point to a local mirror/repo instead. 

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>