### PR TITLE
Release 5.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the lvm cookbook.
 
+## 5.0.5 (2020-11-13)
+
+- Update the attributes gem version from 0.3.5 to 0.3.6 [@gaelik](https://github.com/gaelik)
+
 ## 5.0.4 (2020-10-02)
 
 - Standardise files with files in chef-cookbooks/repo-management - [@xorimabot](https://github.com/xorimabot)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.5'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.6'
 default['lvm']['rubysource'] = 'https://rubygems.org'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs and manages Logical Volume Manager'
-version '5.0.4'
+version '5.0.5'
 %w(amazon centos fedora freebsd oracle redhat scientific suse ubuntu).each do |os|
   supports os
 end


### PR DESCRIPTION
Signed-off-by: Gael Martinez <gael.martinez@gmail.com>

Update the attribute gem to 5.0.5 to add support for RHEL 8.3

### Description
Update the gem pinning to 0.3.6

### Issues Resolved
Fix #198 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>