### PR TITLE
Need to add explicit parameters for super called from action methods

### DIFF
--- a/libraries/provider_lvm_thin_pool.rb
+++ b/libraries/provider_lvm_thin_pool.rb
@@ -34,12 +34,12 @@ class Chef
       end
 
       action :create do
-        super
+        super()
         process_thin_volumes(:create)
       end
 
       action :resize do
-        super
+        super()
         process_thin_volumes(:resize)
       end
 


### PR DESCRIPTION
### Description
I was getting the error:

```
RuntimeError
------------
implicit argument passing of super from method defined by define_method() is not supported. Specify all arguments explicitly.

Cookbook Trace: (most recent call first)
----------------------------------------
/tmp/kitchen/cache/cookbooks/lvm/libraries/provider_lvm_thin_pool.rb:37:in `block in <class:LvmThinPool>'
/tmp/kitchen/cache/cookbooks/lvm/libraries/provider_lvm_volume_group.rb:145:in `block in create_logical_volumes'
/tmp/kitchen/cache/cookbooks/lvm/libraries/provider_lvm_volume_group.rb:143:in `each'
/tmp/kitchen/cache/cookbooks/lvm/libraries/provider_lvm_volume_group.rb:143:in `create_logical_volumes'
/tmp/kitchen/cache/cookbooks/lvm/libraries/provider_lvm_volume_group.rb:61:in `block in <class:LvmVolumeGroup>'
```

This was introduced by the Cookstyle fixes made in
https://github.com/chef-cookbooks/lvm/commit/62256a18537558dbacc9235ecd7999a96d32a91b

Here's the test for this sort of thing in the ruby source:
https://github.com/ruby/ruby/blob/master/test/ruby/test_super.rb#L155

It's been that way since Ruby 1.9.2

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>