### PR TITLE
Update chef-ruby-lvm-attrib to 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the lvm cookbook.
 
+## 5.0.7 (2021-07-22)
+
+- Update the attributes gem version from 0.3.6 to 0.3.7 [@wheatevo](https://github.com/wheatevo)
+
 ## 5.0.6 (2021-02-09)
 
 - Need to add explicit parameters for super called from action methods - [@b-dean](https://github.com/b-dean)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.6'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.7'
 default['lvm']['rubysource'] = 'https://rubygems.org'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs and manages Logical Volume Manager'
-version '5.0.6'
+version '5.0.7'
 %w(amazon centos fedora freebsd oracle redhat scientific suse ubuntu).each do |os|
   supports os
 end


### PR DESCRIPTION
This change updates the chef-ruby-lvm-attrib gem version from 0.3.6 to
0.3.7 to provide support for RHEL/OL 8.4. This has been tested
successfully on the latest RHEL 8.4 ISO.

Signed-off-by: Matthew Newell <matthew.newell@cerner.com>

### Description
This change ensures the latest released version of chef-ruby-lvm-attrib gem is used by the lvm cookbook to support RHEL/OL 8.4.

Unit tests succeeded locally, but the GitHub cookbook pipeline is failing with an HTTP error:
```sh
/usr/bin/docker run --name a33c1014a41428d1c4cf7ab2641e346b111ed_9c964a --label 8a33c1 --workdir /github/workspace --rm -e CHEF_LICENSE -e INPUT_GEMS -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/lvm/lvm":"/github/workspace" 8a33c1:014a41428d1c4cf7ab2641e346b111ed
```

### Issues Resolved
Fixes https://github.com/chef-cookbooks/lvm/issues/208

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>